### PR TITLE
add Restart=always to systemd service unit

### DIFF
--- a/templates/oauth2_proxy@.service.erb
+++ b/templates/oauth2_proxy@.service.erb
@@ -5,6 +5,7 @@ Description=OAuth2 Proxy
 User=<%= scope['::oauth2_proxy::user'] %>
 Group=<%= scope['::oauth2_proxy::group'] %>
 ExecStart=<%= scope['::oauth2_proxy::install_root'] %>/bin/oauth2_proxy --config=/etc/oauth2_proxy/%i.conf
+Restart=always
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
A from source (non-official release) build of `oauth2_proxy` has been
observed to exit unexpectedly with no log output.
