### PR TITLE
feat: make checksum_type configurable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,16 +1,17 @@
 # == Class: oauth2_proxy
 #
 class oauth2_proxy(
-  $user         = $::oauth2_proxy::params::user,
-  $manage_user  = $::oauth2_proxy::params::manage_user,
-  $group        = $::oauth2_proxy::params::group,
-  $manage_group = $::oauth2_proxy::params::manage_group,
-  $install_root = $::oauth2_proxy::params::install_root,
-  $source       = $::oauth2_proxy::params::source,
-  $checksum     = $::oauth2_proxy::params::checksum,
-  $systemd_path = $::oauth2_proxy::params::systemd_path,
-  $shell        = $::oauth2_proxy::params::shell,
-  $provider     = $::oauth2_proxy::params::provider,
+  $user          = $::oauth2_proxy::params::user,
+  $manage_user   = $::oauth2_proxy::params::manage_user,
+  $group         = $::oauth2_proxy::params::group,
+  $manage_group  = $::oauth2_proxy::params::manage_group,
+  $install_root  = $::oauth2_proxy::params::install_root,
+  $source        = $::oauth2_proxy::params::source,
+  $checksum      = $::oauth2_proxy::params::checksum,
+  $checksum_type = $::oauth2_proxy::params::checksum_type,
+  $systemd_path  = $::oauth2_proxy::params::systemd_path,
+  $shell         = $::oauth2_proxy::params::shell,
+  $provider      = $::oauth2_proxy::params::provider,
 ) inherits oauth2_proxy::params {
   validate_string($user)
   validate_bool($manage_user)

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -18,7 +18,7 @@ class oauth2_proxy::install {
     extract       => true,
     extract_path  => $::oauth2_proxy::install_root,
     checksum      => $::oauth2_proxy::checksum,
-    checksum_type => 'sha1',
+    checksum_type => $::oauth2_proxy::checksum_type,
     user          => $::oauth2_proxy::user,
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,10 +12,11 @@ class oauth2_proxy::params {
   $manage_service   = true
   $provider         = 'systemd'
 
-  $version  = '2.1'
-  $tarball  = "oauth2_proxy-${version}.linux-amd64.go1.6.tar.gz"
-  $source   = "https://github.com/bitly/oauth2_proxy/releases/download/v${version}/${tarball}"
-  $checksum = '7a74b361f9edda0400d02602eacd70596d85b453'
+  $version       = '2.1'
+  $tarball       = "oauth2_proxy-${version}.linux-amd64.go1.6.tar.gz"
+  $source        = "https://github.com/bitly/oauth2_proxy/releases/download/v${version}/${tarball}"
+  $checksum      = '7a74b361f9edda0400d02602eacd70596d85b453'
+  $checksum_type = 'sha1'
 
   # in theory, this module should work on any linux distro that uses systemd
   # but it has only been tested on el7


### PR DESCRIPTION
- default stays at sha1
- builds from https://github.com/oauth2-proxy/oauth2-proxy
  are published with sha256 checksums