### PR TITLE
add binary_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,12 @@ to be in `tar.gz` format.
 
 The sha1 format checksum of the `source` file.
 
+##### `binary_path`
+
+`String` defaults to: `bin/oauth2_proxy`
+
+Path to binary execution filename in archive.
+
 ### Defines
 
 #### `oauth2_proxy::instance`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,6 +7,7 @@ class oauth2_proxy(
   $manage_group = $::oauth2_proxy::params::manage_group,
   $install_root = $::oauth2_proxy::params::install_root,
   $source       = $::oauth2_proxy::params::source,
+  $binary_path  = $::oauth2_proxy::params::binary_path,
   $checksum     = $::oauth2_proxy::params::checksum,
   $systemd_path = $::oauth2_proxy::params::systemd_path,
   $shell        = $::oauth2_proxy::params::shell,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,7 +16,7 @@ class oauth2_proxy::params {
   $tarball  = "oauth2_proxy-${version}.linux-amd64.go1.6.tar.gz"
   $source   = "https://github.com/bitly/oauth2_proxy/releases/download/v${version}/${tarball}"
   $checksum = '7a74b361f9edda0400d02602eacd70596d85b453'
-
+  $binary_path   = 'bin/oauth2_proxy'
   # in theory, this module should work on any linux distro that uses systemd
   # but it has only been tested on el7
   case $::osfamily {

--- a/templates/oauth2_proxy.init.erb
+++ b/templates/oauth2_proxy.init.erb
@@ -9,8 +9,8 @@ respawn limit 10 5
 console log
 
 script
-  exec start-stop-daemon --start --make-pidfile --pidfile /var/run/oauth2_proxy@<%= @title %>.pid --chuid <%= scope['::oauth2_proxy::user'] %>:<%= scope['::oauth2_proxy::group'] %> --chdir /opt/oauth2_proxy --startas /bin/bash -- -c "exec <%= scope['::oauth2_proxy::install_root'] %>/bin/oauth2_proxy -config="/etc/oauth2_proxy/<%= @title %>.conf" &>> /var/log/oauth2_proxy/<%= @title %>.log"
-  #exec <%= scope['::oauth2_proxy::install_root'] %>/bin/oauth2_proxy -config="/etc/oauth2_proxy/<%= @title %>.conf" &>> /var/log/oauth2_proxy/<%= @title %>.log
+  exec start-stop-daemon --start --make-pidfile --pidfile /var/run/oauth2_proxy@<%= @title %>.pid --chuid <%= scope['::oauth2_proxy::user'] %>:<%= scope['::oauth2_proxy::group'] %> --chdir /opt/oauth2_proxy --startas /bin/bash -- -c "exec <%= scope['::oauth2_proxy::install_root'] %>/<%= scope['::oauth2_proxy::binary_path'] %> -config="/etc/oauth2_proxy/<%= @title %>.conf" &>> /var/log/oauth2_proxy/<%= @title %>.log"
+  #exec <%= scope['::oauth2_proxy::install_root'] %>/<%= scope['::oauth2_proxy::binary_path'] %> -config="/etc/oauth2_proxy/<%= @title %>.conf" &>> /var/log/oauth2_proxy/<%= @title %>.log
 end script
 
 pre-start script

--- a/templates/oauth2_proxy.initd.erb
+++ b/templates/oauth2_proxy.initd.erb
@@ -19,7 +19,7 @@
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 DESC="oauth2_proxy@<%= @title %>"
 NAME="oauth2_proxy@<%= @title %>"
-DAEMON="<%= scope['::oauth2_proxy::install_root'] %>/bin/oauth2_proxy"
+DAEMON="<%= scope['::oauth2_proxy::install_root'] %>/<%= scope['::oauth2_proxy::binary_path'] %>"
 PIDFILE=/var/run/$NAME.pid
 LOGFILE=/var/log/oauth2_proxy/<%= @title %>.log
 SCRIPTNAME=/etc/init.d/$NAME

--- a/templates/oauth2_proxy@.service.erb
+++ b/templates/oauth2_proxy@.service.erb
@@ -1,10 +1,10 @@
 [Unit]
-Description=OAuth2 Proxy
+Description=OAuth2 Proxy %i
 
 [Service]
 User=<%= scope['::oauth2_proxy::user'] %>
 Group=<%= scope['::oauth2_proxy::group'] %>
-ExecStart=<%= scope['::oauth2_proxy::install_root'] %>/bin/oauth2_proxy --config=/etc/oauth2_proxy/%i.conf
+ExecStart=<%= scope['::oauth2_proxy::install_root'] %>/<%= scope['::oauth2_proxy::binary_path'] %> --config=/etc/oauth2_proxy/%i.conf
 Restart=always
 
 [Install]


### PR DESCRIPTION
With this patch you can fix binary path
For example,if you want to fix path to binary with oauth2-proxy >v6.0.2 add to you hiera:
```yaml
oauth2_proxy::binary_path: 'bin/oauth2-proxy'
```